### PR TITLE
Fix up minor errors in Texinfo documentation, create info file and index file

### DIFF
--- a/histogram_ext-index.lisp
+++ b/histogram_ext-index.lisp
@@ -1,0 +1,14 @@
+(in-package :cl-info)
+(let (
+(deffn-defvr-pairs '(
+; CONTENT: (<INDEX TOPIC> . (<FILENAME> <BYTE OFFSET> <LENGTH IN CHARACTERS> <NODE NAME>))
+("bubbles" . ("histogram_ext.info" 7534 3661 "Definitions for histogram_ext"))
+("histogram_bubbles" . ("histogram_ext.info" 6468 1057 "Definitions for histogram_ext"))
+("histogram_draw" . ("histogram_ext.info" 5600 863 "Definitions for histogram_ext"))
+("histogram_ext" . ("histogram_ext.info" 1996 3598 "Definitions for histogram_ext"))
+))
+(section-pairs '(
+; CONTENT: (<NODE NAME> . (<FILENAME> <BYTE OFFSET> <LENGTH IN CHARACTERS>))
+("Definitions for histogram_ext" . ("histogram_ext.info" 1928 9250))
+)))
+(load-info-hashtables (maxima::maxima-load-pathname-directory) deffn-defvr-pairs section-pairs))

--- a/histogram_ext-index.lisp
+++ b/histogram_ext-index.lisp
@@ -2,9 +2,9 @@
 (let (
 (deffn-defvr-pairs '(
 ; CONTENT: (<INDEX TOPIC> . (<FILENAME> <BYTE OFFSET> <LENGTH IN CHARACTERS> <NODE NAME>))
-("bubbles" . ("histogram_ext.info" 7534 3661 "Definitions for histogram_ext"))
-("histogram_bubbles" . ("histogram_ext.info" 6468 1057 "Definitions for histogram_ext"))
-("histogram_draw" . ("histogram_ext.info" 5600 863 "Definitions for histogram_ext"))
+("bubbles" . ("histogram_ext.info" 7530 3661 "Definitions for histogram_ext"))
+("histogram_bubbles" . ("histogram_ext.info" 6464 1057 "Definitions for histogram_ext"))
+("histogram_draw" . ("histogram_ext.info" 5596 863 "Definitions for histogram_ext"))
 ("histogram_ext" . ("histogram_ext.info" 1996 3598 "Definitions for histogram_ext"))
 ))
 (section-pairs '(

--- a/histogram_ext.info
+++ b/histogram_ext.info
@@ -93,7 +93,7 @@ File: histogram_ext.info,  Node: Definitions for histogram_ext,  Next: Function 
      'LIST'.
 
      Examples:
-          load(“histogram_ext”) 								$
+          load("histogram_ext") 								$
 
           list_test : map( lambda ( [x], (x-50) ),
           				 makelist( random(10000)/100, i, 1, 5000 )
@@ -293,6 +293,6 @@ Tag Table:
 Node: Top298
 Node: Introduction to histogram_ext574
 Node: Definitions for histogram_ext1778
-Node: Function and variable index11201
+Node: Function and variable index11197
 
 End Tag Table

--- a/histogram_ext.info
+++ b/histogram_ext.info
@@ -1,0 +1,298 @@
+This is histogram_ext.info, produced by makeinfo version 6.6 from
+histogram_ext.texi.
+
+INFO-DIR-SECTION Mathematics/Maxima
+START-INFO-DIR-ENTRY
+* histogram_ext: (maxima/histogram_ext).           Maxima share package histogram_ext: additional drawing functions for package draw.
+END-INFO-DIR-ENTRY
+
+
+File: histogram_ext.info,  Node: Top,  Next: Introduction to histogram_ext,  Prev: (dir),  Up: (dir)
+
+histogram_ext
+*************
+
+* Menu:
+
+* Introduction to histogram_ext::
+* Definitions for histogram_ext::
+* Function and variable index::
+
+1 histogram_ext
+***************
+
+
+File: histogram_ext.info,  Node: Introduction to histogram_ext,  Next: Definitions for histogram_ext,  Prev: Top,  Up: Top
+
+2 Introduction to histogram_ext
+*******************************
+
+Package 'histogram_ext' contains user contributed code based on the
+'draw' package.  By Marcus Menzel (2020).
+
+   Package 'histogram_ext' contains user contributed code based on the
+'draw' package and the 'descriptive' package.  Both packages are loaded
+automatically when loading histogram_ext.mac and a histogram structure
+(histogram_structure) will be defined.
+
+   The main goal is to provide more options to express statistical data,
+especially in form of bubble graphs.  Therefor it offers a couple of
+functions to gain histogram distributions from data in list as well as
+matrix form.  This distributions are stored in a structure that can be
+later accessed in an easy and clean way.
+
+   The graphical part offers a basic bubble function as a generic
+function for 'draw2d' and an easier function for presenting histogram
+data in a bubble plot.  All function have several options to influence
+the appearance of the bubbles as well as there position in the graph.
+
+* Menu:
+
+* Definitions for histogram_ext::
+
+
+File: histogram_ext.info,  Node: Definitions for histogram_ext,  Next: Function and variable index,  Prev: Introduction to histogram_ext,  Up: Top
+
+2.1 Definitions for histogram_ext
+=================================
+
+ -- Function: histogram_ext (<LIST>)
+     histogram_ext (<LIST>, <integer>) histogram_ext (<LIST>,
+     <bin-list>)
+
+     Returns a structure containing the histogram results from 'LIST',
+     based on the given options.
+
+     Arguments:
+
+        * <LIST>: can be a flat list of integers, floats or rationals
+          and matrices of rank 1.  The length of 'LIST' must be >2,
+          obvious, otherwise an error is trigged.
+
+        * <integer>: sets this number as symmetric bins in between the
+          lowest and highest values from 'LIST'.
+
+        * <bin-list>: is a nested list given all numbers in the form [
+          [low_1, high_1],[low_2,high_2],...  ] the bins will be counted
+          accordingly.  A zero distance is fine, but the list needs to
+          be sorted in ascending order to make sure no unwanted counting
+          happens.  If the classes don't match all list members, the
+          total value in the resulting structure will differ from
+          'LIST'.
+
+     Providing a 'LIST' only sets the number of symmetric bin according
+     to an algorithm described by Freedman and Diaconis "n the histogram
+     as a density estimator: L_2 theory.  " in Zeitschrift für
+     Wahrscheinlichkeitstheorie und verwandte Gebiete.  Band 57, Nr.  4,
+     1981, S. 453.
+
+     The output is a structure of type _histogram_structure_ with the
+     internal lists (bounds, distance, count, mass_fraction,
+     area_fraction, service), the last gives the minimal, maximal and
+     total sum of values from the 'LIST' and further information about
+     'LIST'.
+
+     Examples:
+          load(“histogram_ext”) 								$
+
+          list_test : map( lambda ( [x], (x-50) ),
+          				 makelist( random(10000)/100, i, 1, 5000 )
+          			)										$
+          remvalue( example )									$
+          example   : new( histogram_structure )				$
+          example   : histogram_ext( list_test )				;
+          histogram_draw ( example, 'mass )					$
+          example   : histogram_ext( list_test, 40 )			$
+          histogram_draw ( example, 'mass )					$
+
+          list_bins : [ [0,1],[1,2],[2,3],[4,4],[5,5],
+          			  [51/10,55/10],[8.0,9.9]
+          			]										$
+          remvalue( example )									$
+          example   : new( histogram_structure )				$
+          example   : histogram_ext( list_test, list_bins )	$
+          histogram_draw ( example, 'area )					$
+
+          remvalue( example )									$
+          example   : new( histogram_structure )				$
+          example   : histogram_ext( list_test,
+                               makelist([i-1,i+1],i,0,14,2)
+          			)										$
+          histogram_draw ( example, fill_color = red )		$
+
+          load("histogram_ext.mac")									$
+
+          STRUCT : histogram_ext(
+              makelist( random(30), 200 ) ,
+              makelist( [i,i+DELTA], i, 0, 30, DELTA )  )   ,DELTA=2 	$
+
+          draw2d(
+              histogram_bubbles( STRUCT , 'mass,
+          		bubble_tilt = 17,  bubble_fill = green )			,
+              histogram_bubbles( STRUCT2, 'mass,
+                  bubble_x=2, bubble_tilt=17, bubble_fill=FANCY , bubble_line=white ) ,
+              xtics  = { ["HISTROGRAM_{No1}", 1], ["HISTROGRAM_{No2}", 2] },
+              xrange = [ 0.5, 2.5 ],
+              grid   = true
+          )   														,
+          STRUCT2 = histogram_ext( makelist( random(30), 200 ) ,
+          						 makelist( [i,i+1], i, 0, 30, 1 ))	,
+          FANCY   = makelist(
+                      printf(false,"#~2,'0x~2,'0x~2,'0x~2,'0x",i*5+60,100,100,0),
+                      i, 0, 30, 1 ) 									$
+
+ -- Function: histogram_draw (<STRUCT>, <options>)
+
+     Draws the result from <STRUCT> according to the given options in a
+     'draw2d' graph and is affected by all options from the 'bars'
+     function.
+
+     Options:
+        * histogram_draw ( <STRUCT> )
+        * histogram_draw ( <STRUCT>, <type> )
+        * histogram_draw ( <STRUCT>, <type>, <bars_options> )
+
+     The accepted <STRUCT> is of type _histogram_structure_ as delivered
+     by 'histogram_ext' function.
+
+     The possible “<type>”s are 'area, 'mass, 'count and access the
+     normalized area , the mass fraction and the as counted values from
+     the _histogram_structure_, respectively.
+
+     See 'histogram_ext' for a complete description and for a complete
+     list of options see also function 'bars' from package 'draw2d'.  In
+     WxMaxima you are able to use 'wxhistogram_draw()'.
+
+ -- Function: histogram_bubbles (<STRUCT>, <options>)
+
+     Draws a bubble series in 2D. The purpose of this function is to
+     make it easier for the user to use function bubble with histogram
+     data.
+
+     Options:
+        * histogram_bubbles ( <STRUCT> )
+        * histogram_bubbles ( <STRUCT>, <type> )
+        * histogram_bubbles ( <STRUCT>, <type>, <bars_options> )
+
+     The accepted <STRUCT> is of type _histogram_structure_ as delivered
+     by 'histogram_ext' function.  The possible “type”s are 'area,
+     'mass, 'count and access the normalized area , the mass fraction
+     and the as counted values from the _histogram_structure_,
+     respectively.
+
+     The possible “<type>”s are 'area, 'mass, 'count and access the
+     normalized area , the mass fraction and the as counted values from
+     the _histogram_structure_, respectively.
+
+     See 'histogram_ext' for a complete description and for a complete
+     list of options see also function 'bars' from package 'draw2d'.  In
+     WxMaxima you are able to use 'wxhistogram_draw()'.
+
+ -- Function: bubbles (<LIST> or <MATRIX>, <options>)
+
+     Draws a bubble series in 2D.
+
+     Options:
+        * bubbles ( <LIST> )
+        * bubbles ( <LIST>, <options> )
+        * bubbles ( <MATRIX> )
+        * bubbles ( <MATRIX>, <options> )
+
+     The <LIST> has to be a nested list containing the x, y coordinates
+     then the radius value and the fill_color [ [x_1, x_2, .., x_n],
+     [y_1, y_2, …, y_n], [r_1, r_2, …, r_n], [fill_color_1,
+     fill_color_2, …, fill_color_n] ] or a <LIST> with an additional
+     nested list for line_color.  The length of all nested lists needs
+     to be the same.
+
+          load("histogram_ext.mac")$
+
+          /*
+              All lists need to be of same length.
+              Be aware that there are no negative radii - see example.
+              Bubbles takes nested lists or rectangular tansposed matricies only.
+           */
+          FROM    :   0   $
+          TO      :   8   $
+          DISTANCE:   1/5 $
+          atPOINT :   makelist( i, i, FROM , TO, DISTANCE )   $
+          list_x  :   makelist( i,        i, atPOINT )        $
+          list_y  :   makelist( 1,        i, atPOINT )        $
+          list_r  :   makelist( sin(i),   i, atPOINT )        $
+          list_RGB:   makelist(
+                        printf(false, "#~2,'0x~2,'0x~2,'0x~2,'0x", 250-i*25, 150, 90, 0),
+                        i, atPOINT 				   ) 		$
+          list_LL :   makelist(
+                        printf(false, "#~2,'0x~2,'0x~2,'0x~2,'0x", 110, i*25, 190, 0)   ,
+                        i, atPOINT 				   ) 		$
+          CONTXT  :   transpose(
+                        apply(matrix,
+                          [ list_x, list_y+2, list_r, list_RGB, list_LL ]
+                             )					   )		$
+          CONTXT  :   [ list_x, list_y+2, list_r, list_RGB, list_LL ]	$
+
+          wxdraw2d(
+              points_joined   =   true		,
+              point_size      =   0       	,
+              points([[0,3],[8,3]])    		,
+              bubbles( [list_x, list_y, log(reverse(atPOINT)+1), list_RGB] )	,
+          	/* next example shows how to adapt the bubble size to the real function */
+              bubbles( CONTXT, bubble_scale_x = 0.2  ),
+              color           =   blue		,
+              points( atPOINT, sin(atPOINT)+3),
+           	bubbles( [ list_x, 4+list_y , cos(atPOINT), list_RGB ],
+          			 bubble_line=white )	,
+              grid=true
+          )
+
+
+     In case of providing a <MATRIX> be aware of the transposed
+     orientation, otherwise <LIST> and <MATRIX> behave the same (see
+     CONTXT in the example above).
+
+     Recognized options:
+        * 'bubble_line = line_color' for all bubbles (preset = gray60)
+          See HTML color code or color names in function 'color' for
+          package 'DRAW'.  Here is only one color value possible, for
+          separate color use the extended <LIST>.
+        * 'bubble_tilt = real positive number ' (preset = 1) changes the
+          elongation in y direction higher values stretches the bubbles
+          lower values than 1 compress.  Be aware that using this option
+          changes the drawn values - it is an eye-candy option.
+        * 'bubble_scale_x = real positive number' (preset = 1) changes
+          the elongation in x direction higher values stretches the
+          bubbles lower values than 1 compress.  Useful if many bubble
+          colums are drawn in one graph.  Be aware that using this
+          option changes the drawn values - it is an eye-candy option.
+
+     Further options are called before the graphic objects.  There
+     effect might be limited, except of global options for the draw2d
+     objects.
+
+
+File: histogram_ext.info,  Node: Function and variable index,  Prev: Definitions for histogram_ext,  Up: Top
+
+Appendix A Function and variable index
+**************************************
+
+ [index ]
+* Menu:
+
+* bubbles:                               Definitions for histogram_ext.
+                                                              (line 138)
+* histogram_bubbles:                     Definitions for histogram_ext.
+                                                              (line 113)
+* histogram_draw:                        Definitions for histogram_ext.
+                                                              (line  91)
+* histogram_ext:                         Definitions for histogram_ext.
+                                                              (line   6)
+
+
+
+Tag Table:
+Node: Top298
+Node: Introduction to histogram_ext574
+Node: Definitions for histogram_ext1778
+Node: Function and variable index11201
+
+End Tag Table

--- a/histogram_ext.texi
+++ b/histogram_ext.texi
@@ -68,7 +68,7 @@ The output is a structure of type @emph{histogram_structure} with the internal l
 
 Examples:
 @example
-load(“histogram_ext”) 								$
+load("histogram_ext") 								$
 
 list_test : map( lambda ( [x], (x-50) ),
 				 makelist( random(10000)/100, i, 1, 5000 )

--- a/histogram_ext.texi
+++ b/histogram_ext.texi
@@ -22,17 +22,15 @@
 @top
 @menu
 * Introduction to histogram_ext::
-* histogram_ext::
-* histogram_draw::
-* histogram_bubbles::
-* bubbles
+* Definitions for histogram_ext::
 * Function and variable index::
 @end menu
+@chapter histogram_ext
 
-@node Introduction to histogram_ext, descriptive, Top, Top
+@node Introduction to histogram_ext, Definitions for histogram_ext, Top, Top
 @chapter Introduction to histogram_ext
 
-Package @code{histogram_ext} contains user contributed code based on the @code{draw} package.
+Package @code{histogram_ext} contains user contributed code based on the @code{draw} package. By Marcus Menzel (2020).
 
 Package @code{histogram_ext} contains user contributed code based on the @code{draw} package and the @code{descriptive} package. Both packages are loaded automatically when loading histogram_ext.mac and a histogram structure (histogram_structure) will be defined.
 
@@ -40,13 +38,8 @@ The main goal is to provide more options to express statistical data, especially
 
 The graphical part offers a basic bubble function as a generic function for @code{draw2d} and an easier function for presenting histogram data in a bubble plot. All function have several options to influence the appearance of the bubbles as well as there position in the graph.
 
-
-@node histogram structures, bubble diagrams, Introduction to histogram_ext, Top
-@chapter  Histogram Extensions
-
-By Marcus Menzel (2020)
-
-Functions for drawing histograms as bars or bubbles graphs in 2D. A function for making histogram structures from data line or rows in matrices for further use.
+@node Definitions for histogram_ext, Function and variable index, Introduction to histogram_ext, Top
+@section Definitions for histogram_ext
 
 @deffn {Function} histogram_ext (@var{LIST})
 histogram_ext (@var{LIST}, @var{integer})
@@ -115,7 +108,7 @@ draw2d(
 		bubble_tilt = 17,  bubble_fill = green )			,
     histogram_bubbles( STRUCT2, 'mass, 
         bubble_x=2, bubble_tilt=17, bubble_fill=FANCY , bubble_line=white ) ,
-    xtics  = { ["HISTROGRAM_{No1}", 1], ["HISTROGRAM_{No2}", 2] },
+    xtics  = @{ ["HISTROGRAM_@{No1@}", 1], ["HISTROGRAM_@{No2@}", 2] @},
     xrange = [ 0.5, 2.5 ],
     grid   = true
 )   														,   
@@ -128,13 +121,6 @@ FANCY   = makelist(
 
 @end deffn
 
-@node  Draw extensions
-@chapter Histogram drawings
-
-By Marcus Menzel (2020)
-
-No known bug, but in case some issue needs to be addressed, please share it on 
-Maxima mailing list.
 
 @deffn {Function} histogram_draw (@var{STRUCT}, @var{options})
 
@@ -155,7 +141,7 @@ The accepted @var{STRUCT} is of type @emph{histogram_structure} as delivered by 
 
 The possible “@var{type}”s are 'area, 'mass, 'count and access the normalized area , the mass fraction and the as counted values from the @emph{histogram_structure}, respectively.
 
-See @code{histogram_ext} for a complete description and for a complete list of options see also function code{bars} from package @code{draw2d}. In WxMaxima you are able to use @code{wxhistogram_draw()}.
+See @code{histogram_ext} for a complete description and for a complete list of options see also function @code{bars} from package @code{draw2d}. In WxMaxima you are able to use @code{wxhistogram_draw()}.
 @end deffn
 
 
@@ -179,7 +165,7 @@ The accepted @var{STRUCT} is of type @emph{histogram_structure} as delivered by 
 
 The possible “@var{type}”s are 'area, 'mass, 'count and access the normalized area , the mass fraction and the as counted values from the @emph{histogram_structure}, respectively.
 
-See @code{histogram_ext} for a complete description and for a complete list of options see also function code{bars} from package @code{draw2d}. In WxMaxima you are able to use @code{wxhistogram_draw()}.
+See @code{histogram_ext} for a complete description and for a complete list of options see also function @code{bars} from package @code{draw2d}. In WxMaxima you are able to use @code{wxhistogram_draw()}.
 
 @end deffn
 
@@ -267,3 +253,11 @@ Further options are called before the graphic objects. There effect might be lim
 
 
 @end deffn
+
+
+@node Function and variable index,  , Definitions for histogram_ext, Top
+@appendix Function and variable index
+@printindex fn
+@printindex vr
+
+@bye

--- a/rtest_histogram_previous.mac
+++ b/rtest_histogram_previous.mac
@@ -1,0 +1,160 @@
+(if ?mget (histogram_description, ?mexpr) = false
+   then load (descriptive),
+ 0);
+0;
+
+/* data can be: list, one row matrix, one column matrix */
+
+block ([xx, h1, h2, h3],
+       xx: makelist (random (400) / 4.0, 100),
+       h1: histogram_description (xx),
+       h2: histogram_description (matrix (xx)),
+       h3: histogram_description (transpose (matrix (xx))),
+       h1 = h2 and h2 = h3);
+true;
+
+/* nclasses (default: 10) can be:
+   number of bins,
+   or [class_min, class_max, nclasses],
+   or [class_min, class_max],
+   or {min_1, min_2, min_3, ...},
+   or a symbol, 'fd, 'scott, or 'sturges
+ */
+
+(find_expr (o, e) := sublist (args (e), lambda ([a], not atom(a) and op(a) = o)),
+ find_bars (e) := block ([b: find_expr ('bars, e)], if b # [] then b[1]),
+ 0);
+0;
+
+block ([xx, h1, h2],
+       xx: makelist (random (400) / 4.0, 128),
+       h1: histogram_description (xx),
+       h2: histogram_description (xx, nclasses = 10),
+       is (h1 = h2));
+true;
+
+block ([xx, h],
+       xx: makelist (random (400) / 4.0, 100),
+       h: histogram_description (xx, nclasses = 17),
+       length (find_bars (h)));
+17;
+
+block ([xx, h],
+       xx: makelist (random (400) / 4.0, 100),
+       h: histogram_description (xx, nclasses = [43, 85, 13]),
+       length (find_bars (h)));
+13;
+
+block ([xx, h],
+       xx: makelist (random (400) / 4.0, 100),
+       h: histogram_description (xx, nclasses = [43, 85]),
+       length (find_bars (h)));
+10;
+
+block ([xx, h],
+       xx: makelist (random (400) / 4.0, 100),
+       S: setify (primes (2, 100)),
+       h: histogram_description (xx, nclasses = S),
+       length (find_bars (h)));
+''(length (S) - 1);
+
+(xx:makelist(i/4.0, i, 0, 400), 0);
+0;
+
+histogram_description (xx, nclasses = 'scott);
+[[], xrange = [- 6.25, 106.25], yrange = [- 2.55, 53.55], [], 
+bars([6.25, 51.0, 12.5], [18.75, 50.0, 12.5], [31.25, 50.0, 12.5], 
+[43.75, 50.0, 12.5], [56.25, 50.0, 12.5], [68.75, 50.0, 12.5], 
+[81.25, 50.0, 12.5], [93.75, 50.0, 12.5])];
+
+histogram_description (xx, nclasses = 'fd);
+[[], xrange = [- 6.25, 106.25], yrange = [- 2.55, 53.55], [], 
+bars([6.25, 51.0, 12.5], [18.75, 50.0, 12.5], [31.25, 50.0, 12.5], 
+[43.75, 50.0, 12.5], [56.25, 50.0, 12.5], [68.75, 50.0, 12.5], 
+[81.25, 50.0, 12.5], [93.75, 50.0, 12.5])];
+
+histogram_description (xx, nclasses = 'sturges);
+[[], xrange = [- 5.0, 105.0], yrange = [- 2.05, 43.05], [], 
+bars([5.0, 41.0, 10.0], [15.0, 40.0, 10.0], [25.0, 40.0, 10.0], 
+[35.0, 40.0, 10.0], [45.0, 40.0, 10.0], [55.0, 40.0, 10.0], 
+[65.0, 40.0, 10.0], [75.0, 40.0, 10.0], [85.0, 40.0, 10.0], 
+[95.0, 40.0, 10.0])];
+
+/*
+   <frequency> (default, 'absolute'): indicates the scale of the
+   ordinates.  Possible values are: 'absolute', 'relative',
+   'percent', and 'density'.  With 'density', the histogram area
+   has a total area of one.
+ */
+
+block ([xx, h1, h2],
+       xx: makelist (random (400) / 4.0, 128),
+       h1: histogram_description (xx),
+       h2: histogram_description (xx, frequency = 'absolute),
+       is (h1 = h2));
+true;
+
+block ([xx, h],
+       xx: makelist (random (400) / 4.0, 128),
+       h: histogram_description (xx, frequency = 'absolute),
+       block ([b: find_bars (h)], lsum (n, n, maplist (second, b))));
+128.0;
+
+block ([xx, h],
+       xx: makelist (random (400) / 4.0, 64),
+       h: histogram_description (xx, frequency = 'relative),
+       block ([b: find_bars (h)], lsum (n, n, maplist (second, b))));
+1.0;
+
+block ([xx, h],
+       xx: makelist (random (400) / 4.0, 256),
+       h: histogram_description (xx, frequency = 'percent),
+       block ([b: find_bars (h)], lsum (n, n, maplist (second, b))));
+100.0;
+
+block ([xx, h],
+       xx: makelist (random (400) / 4.0, 128),
+       h: histogram_description (xx, frequency = 'density),
+       lsum (b[2]*b[3], b, args (find_bars (h))));
+1.0;
+
+/*
+   <htics> (default, 'auto'): format of the histogram tics.
+   Possible values are: 'auto', 'endpoints', 'intervals', or a
+   list of labels.
+ */
+
+block ([xx, h1, h2],
+       xx: makelist (random (400) / 4.0, 128),
+       h1: histogram_description (xx),
+       h2: histogram_description (xx, htics = 'auto),
+       is (h1 = h2));
+true;
+
+block ([xx, h],
+       xx: makelist (random (400) / 4.0, 128),
+       h: histogram_description (xx, htics = 'auto),
+       assoc ('xtics, find_expr ("=", h)));
+false;
+
+block ([xx, h],
+       xx: makelist (random (400) / 4.0, 128),
+       tics_set: {3.0, 13.0, 33.0, 66.0, 99.0},
+       h: histogram_description (xx, htics = 'endpoints, nclasses = tics_set),
+       assoc ('xtics, find_expr ("=", h)));
+''tics_set;
+
+block ([xx, h],
+       xx: makelist (random (400) / 4.0, 128),
+       tics_set: { 10.0, 20.0, 40.0, 80.0, 90.0, 95.0 },
+       h: histogram_description (xx, htics = 'intervals, nclasses = tics_set),
+       assoc ('xtics, find_expr ("=", h)));
+{["(20.0,40.0]", 30.0], ["(40.0,80.0]", 60.0], ["(80.0,90.0]", 85.0], ["(90.0,95.0]", 92.5], ["[10.0,20.0]", 15.0]};
+
+block ([xx, h],
+       xx: makelist (random (400) / 4.0, 128),
+       tics_list: ["A", "B", "C", "D", "E"],
+       h: histogram_description (xx, htics = tics_list, nclasses = tics_set),
+       assoc ('xtics, find_expr ("=", h)));
+{["A", 15.0], ["B", 30.0], ["C", 60.0], ["D", 85.0], ["E", 92.5]};
+


### PR DESCRIPTION
I've fixed up some minor errors in the Texinfo documentation, and created a .info file, and a Maxima documentation index. Although the .info and index file are generated files, I think it's helpful to have these defined so that users don't have to generate them. The .texi typically is updated only infrequently, so it's not a problem to regenerate the .info and index on those rare occasions.
